### PR TITLE
debug: enable the Neo4j web server

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -57,6 +57,9 @@ However, for most projects it is required to configure more options.
     # Enable Metrics
     --enable-metrics
 
+    # Enable Neo4j web server on localhost, for debugging and exploring the database only. PORT is optional, default is 7575.
+    --neo4j-webserver PORT
+
 Running Obelix as a Daemon (background service) on Ubuntu 14.04
 --------------------------
 In a production environment it is wise to run Obelix as a background service.

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>Neo4j releases</id>
+            <url>http://m2.neo4j.org/content/repositories/releases</url>
+        </repository>
+    </repositories>
+
     <build>
         <pluginManagement>
             <plugins>
@@ -97,6 +104,19 @@
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j</artifactId>
             <version>2.2.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.neo4j.app</groupId>
+            <artifactId>neo4j-server</artifactId>
+            <version>2.2.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.neo4j.app</groupId>
+            <artifactId>neo4j-server</artifactId>
+            <version>2.2.1</version>
+            <classifier>static-web</classifier>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The integrated use of the web server (in embedded mode) is deprecated, but its useful for debugging and exploring the database.

Also useful for maybe switching to the cypher or Rest API.
See: [stackoverflow - use of the embedded server](http://stackoverflow.com/questions/30074232/replacement-for-deprecated-wrappingneoserverbootstrapper/30074869#30074869 )